### PR TITLE
fix-24: Fix views old data

### DIFF
--- a/Friendly/Sources/ProfileEdit/ProfileEditView.swift
+++ b/Friendly/Sources/ProfileEdit/ProfileEditView.swift
@@ -74,7 +74,7 @@ struct ProfileEditView: View {
             }
         }
         .onDisappear {
-            viewModel.dismiss()
+            viewModel.cancelTasks()
         }
     }
 }

--- a/Friendly/Sources/ProfileEdit/ProfileEditViewModel.swift
+++ b/Friendly/Sources/ProfileEdit/ProfileEditViewModel.swift
@@ -68,9 +68,13 @@ class ProfileEditViewModel {
     }
     
     func dismiss() {
+        cancelTasks()
+        onComplete()
+    }
+
+    func cancelTasks() {
         uploadTask?.cancel()
         saveTask?.cancel()
-        onComplete()
     }
 
     func upload(_ data: Data) {

--- a/Friendly/Sources/ProfileView.swift
+++ b/Friendly/Sources/ProfileView.swift
@@ -31,6 +31,9 @@ struct ProfileView: View {
         .background(Color(uiColor: .systemGroupedBackground))
         .sheet(
             isPresented: $viewModel.shouldEditProfile,
+            onDismiss: {
+                viewModel.editProfileDismissed()
+            },
         ) {
             let profileInfo: ProfileInfo? = switch viewModel.state {
             case .success(let success): success
@@ -66,7 +69,7 @@ struct ProfileView: View {
                 }
                 if showLink {
                     Button {
-                        openUrl(viewModel.success.socialUrl!)
+                        openSocialLink(viewModel.success.socialUrl!)
                     } label: {
                         Image(systemName: "paperplane")
                             .font(.headline)
@@ -140,6 +143,17 @@ struct ProfileView: View {
             }
         }
         .refreshable { await viewModel.reload() }
+    }
+
+    private func openSocialLink(_ url: URL) {
+        let destination =
+            if url.scheme == nil {
+                URL(string: "https://\(url.absoluteString)")
+            } else {
+                url
+            }
+        guard let destination else { return }
+        openUrl(destination)
     }
 
     enum Mode {

--- a/Friendly/Sources/ProfileViewModel.swift
+++ b/Friendly/Sources/ProfileViewModel.swift
@@ -21,15 +21,7 @@ class ProfileViewModel {
 
     let enableSignOut: Bool
     let enableRemoveFromFriends: Bool
-    var shouldEditProfile: Bool = false {
-        didSet {
-            if !shouldEditProfile {
-                Task {
-                    await reload()
-                }
-            }
-        }
-    }
+    var shouldEditProfile: Bool = false
     
     func showEditProfile() {
         shouldEditProfile = true
@@ -49,6 +41,7 @@ class ProfileViewModel {
 
     private let storage: Storage = .shared
     private let networkClient: NetworkClient = .meetacy
+    private var reloadTask: Task<Void, Never>?
 
     private(set) var state: State = .loading
     private(set) var alertError: AlertError? = nil
@@ -63,12 +56,33 @@ class ProfileViewModel {
     }
 
     func appear() {
-        Task {
-            await reload()
-        }
+        startReload()
+    }
+
+    func editProfileDismissed() {
+        startReload()
     }
 
     func reload() async {
+        let task = makeReloadTask()
+        await task.value
+    }
+
+    private func startReload() {
+        makeReloadTask()
+    }
+
+    @discardableResult
+    private func makeReloadTask() -> Task<Void, Never> {
+        reloadTask?.cancel()
+        let task = Task<Void, Never> { [weak self] in
+            _ = await self?.performReload()
+        }
+        reloadTask = task
+        return task
+    }
+
+    private func performReload() async {
         do {
             let authorization = try storage.loadAuthorization()
             let id = switch mode {
@@ -84,6 +98,14 @@ class ProfileViewModel {
                 id: id,
                 accessHash: accessHash,
             )
+            try Task.checkCancellation()
+
+            let currentAuthorization = try storage.loadAuthorization()
+            guard currentAuthorization.id == authorization.id,
+                  currentAuthorization.token == authorization.token else {
+                return
+            }
+
             let url: URL? = if let avatar = userDetails.avatar {
                 networkClient.filesDownloadUrl(for: avatar)
             } else {
@@ -103,12 +125,16 @@ class ProfileViewModel {
                 socialUrl: socialUrl,
             )
             state = .success(success)
+        } catch is CancellationError {
+            return
         } catch {
+            guard !Task.isCancelled else { return }
             state = .ioError
         }
     }
 
     func signOut() {
+        reloadTask?.cancel()
         storage.clearAuthorization()
         selfProfile.routeToSignUp()
     }

--- a/Friendly/Sources/Transport.swift
+++ b/Friendly/Sources/Transport.swift
@@ -140,7 +140,10 @@ struct Transport {
         authorization: Authorization
     )  -> URLRequest {
         let url = baseUrl.appending(path: path)
-        var request = URLRequest(url: url)
+        var request = URLRequest(
+            url: url,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+        )
         let httpMethod = switch method {
         case .get: "GET"
         case .post: "POST"
@@ -150,6 +153,10 @@ struct Transport {
         request.setValue(
             "application/json",
             forHTTPHeaderField: "Content-Type",
+        )
+        request.setValue(
+            "no-cache",
+            forHTTPHeaderField: "Cache-Control",
         )
         request.setValue(
             authorization.token.string,


### PR DESCRIPTION
The exact cause of the QR issue could not be reliably reproduced. However, this change fixes a potential stale-data race. This should reduce the risk of displaying or using data from a previous account.